### PR TITLE
teach the compiler stop compiling and bark at the user

### DIFF
--- a/Servo8Bit.cpp
+++ b/Servo8Bit.cpp
@@ -507,7 +507,7 @@ void ServoSequencer::setupTimerPrescaler()
             TCCR0B &= ~(1<< CS00); //clear
         #else
             //unsupported clock speed
-            //TODO: find a way to have the compiler stop compiling and bark at the user
+        #error Unsupported clock speed. This code will only operate at 8Mhz or 1Mhz
         #endif
     #endif
 
@@ -533,7 +533,7 @@ void ServoSequencer::setupTimerPrescaler()
             TCCR1 &= ~(1<< CS10); //clear
         #else
             //unsupported clock speed
-            //TODO: find a way to have the compiler stop compiling and bark at the user
+        #error Unsupported clock speed. This code will only operate at 8Mhz or 1Mhz
         #endif
     #endif
 }//end setupTimerPrescaler


### PR DESCRIPTION
Servo8Bit.cpp only supports 8Mhz and 1Mhz clock speeds. It includes
the following comment:

    #else
        //unsupported clock speed
        //TODO: find a way to have the compiler stop compiling and bark at the user
    #endif

By placing an #error directive in that #else block, we can cause the
compiler to do exactly that.