### PR TITLE
Constructor bug fix

### DIFF
--- a/Servo8Bit.cpp
+++ b/Servo8Bit.cpp
@@ -782,7 +782,7 @@ ISR(TIM1_COMPA_vect)
 //=============================================================================
 Servo8Bit::Servo8Bit()
 :invalidServoNumber(ServoSequencer::kInvalidServoIndex),
- myServoNumber(invalidServoNumber),
+ myServoNumber(ServoSequencer::kInvalidServoIndex),
  myMin(kDefaultMinimalPulse),
  myMax(kDefaultMaximumPulse)
 {


### PR DESCRIPTION
The library doesn't work in Arduino 1.8.9 because of a C++ problem in the Servo8Bit constructor. myServoNumber is initialised as 0 instead of invalidServoNumber: the constructor requires a specific order in which the assignments should be executed, but this is not guaranteed. This results is that the register function is not being called and nothing is happening. Changing the default for myServoNumber to ServoSequencer::kInvalidServoIndex instead of invalidServoNumber fixes the problem.